### PR TITLE
took away flashing titles on clusters

### DIFF
--- a/static/js/textMining.js
+++ b/static/js/textMining.js
@@ -701,10 +701,6 @@ function drawAll(error, dataset) {
     } else {
       $('#banner').show();
     }
-
-    // var clusterIndico = findCluster(node);
-    // var info = clusterIndico.info.keywords.join(', ');
-    // $('#banner > span').text(info);
   }
 
   document.getElementById('tooltip').addEventListener('mouseover', function(e) {

--- a/static/js/textMining.js
+++ b/static/js/textMining.js
@@ -284,6 +284,8 @@ function drawAll(error, dataset) {
       chosenContext.stroke();
 
       if (node.cluster == focus.cluster && !node.holder) {
+        // For wrapping text on all of the nodes in the zoomed-in
+        // cluster.
         wrapText(context, node);
       }
 
@@ -300,6 +302,9 @@ function drawAll(error, dataset) {
       var holder = holders[i];
 
       if (holder.cluster != activeCluster || activeCluster == -1) {
+        // For adding cluster keywords on top of all the cluster
+        // circles. activeCluster == -1 when your mouse is not on
+        // any clusters.
         wrapText(context, holder);
       }
     } // for i in holders

--- a/static/js/textMining.js
+++ b/static/js/textMining.js
@@ -133,7 +133,6 @@ function drawAll(error, dataset) {
   for (var i=0; i<nodes.length; i++) {
     var node = nodes[i]
     if (node.holder) {
-      console.log(node);
       holders.push(node);
     }
     node.border = false;
@@ -300,8 +299,8 @@ function drawAll(error, dataset) {
     for (var i=0; i<holders.length; i++) {
       var holder = holders[i];
 
-      if (!(holder.cluster == activeCluster) && holder.children) {
-        if (focus.cluster != holder.cluster) wrapText(context, holder);
+      if (holder.cluster != activeCluster || activeCluster == -1) {
+        wrapText(context, holder);
       }
     } // for i in holders
 
@@ -608,6 +607,7 @@ function drawAll(error, dataset) {
       }
       currentNode.selected = (!currentNode.holder)? true : false;
     } else {
+      setBanner({});
       zoomToCanvas(root);
     }
   
@@ -694,16 +694,16 @@ function drawAll(error, dataset) {
   }
 
   function setBanner(node) {
-    if (node.top == true || !node.cluster || Object.is(node, {})) {
+    if (!Object.keys(node).length) {
+      console.log('cooock');
       $('#banner').hide();
       return
     } else {
       $('#banner').show();
     }
 
-    var clusterIndico = findCluster(node);
-    var info = clusterIndico.info.keywords.join(', ');
-
+    // var clusterIndico = findCluster(node);
+    // var info = clusterIndico.info.keywords.join(', ');
     // $('#banner > span').text(info);
   }
 
@@ -742,22 +742,21 @@ function drawAll(error, dataset) {
       drawCanvas(hiddenContext, true);
 
       if (currentNode) {
+        setBanner(currentNode);
         currentNode.border = true;
         activeCluster = (currentNode.top)? -1 : currentNode.cluster;
 
-        setBanner(currentNode);
         if (!Object.is(focus, root)) setTooltip(currentNode, e.clientX, e.clientY);
 
         if (currentNode.cluster != undefined) {
           var cluster = findCluster(currentNode);
-          setBanner(cluster);
           cluster.border = true;
         }
       } else {
-        activeCluster = -1;
-        setBanner({});
         setTooltip({}, 0, 0);
       }
+
+      if (activeCluster === -1) setBanner({});
     }
 
   });
@@ -793,7 +792,6 @@ function drawAll(error, dataset) {
 
     if (focusNode == root) {
       slideInfoOut(dataset, 'top');
-      setBanner({});
       $('#zoomOut').animate({ 'opacity': 0});
     } else if (focusNode.holder) {
       slideInfoOut(focusNode, 'cluster');

--- a/static/js/textMining.js
+++ b/static/js/textMining.js
@@ -607,7 +607,7 @@ function drawAll(error, dataset) {
       }
       currentNode.selected = (!currentNode.holder)? true : false;
     } else {
-      setBanner({});
+      $('#banner').hide();
       zoomToCanvas(root);
     }
   
@@ -693,16 +693,6 @@ function drawAll(error, dataset) {
     $('#tooltip').show();
   }
 
-  function setBanner(node) {
-    if (!Object.keys(node).length) {
-      console.log('cooock');
-      $('#banner').hide();
-      return
-    } else {
-      $('#banner').show();
-    }
-  }
-
   document.getElementById('tooltip').addEventListener('mouseover', function(e) {
     $('#tooltip').stop(true, true);
     $('#tooltip').hide();
@@ -738,7 +728,7 @@ function drawAll(error, dataset) {
       drawCanvas(hiddenContext, true);
 
       if (currentNode) {
-        setBanner(currentNode);
+        $('#banner').show();
         currentNode.border = true;
         activeCluster = (currentNode.top)? -1 : currentNode.cluster;
 
@@ -752,7 +742,7 @@ function drawAll(error, dataset) {
         setTooltip({}, 0, 0);
       }
 
-      if (activeCluster === -1) setBanner({});
+      if (activeCluster === -1) $('#banner').hide();
     }
 
   });


### PR DESCRIPTION
## Reviewers: 

<!--- Check yourself off the list after review -->
- [ ] @sihrc 
## What's the purpose of the PR?

https://trello.com/c/5P4eVep2/1930-remove-flashing-of-titles-in-theme-extraction
Fixing the way the cluster keyword overlays flash when you're on the cluster and made the banner less spazzy
## Description of changes

Just changing wrapText state when entering a new cluster.
## Notes to reviewers

<!--- For the reviewer -->
## Keep in mind while reviewing code:
- Is relevant code tested?
- Are added functions/methods documented?
- Separation of concerns (SOC)
- Don't repeat yourself (DRY) 
- Limit the number of positional arguments
- Is function/method length reasonable?
- Can code be broken down into smaller components?
- Where do added functions/methods belong?
- Are variable names descriptive?
- Are errors handled appropriately?
- Can logic be simplified?
- Does the code make sense in context? (expand the diff)
